### PR TITLE
Update Protocol Buffers documentation URL

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -2,7 +2,7 @@
 
 Protocol Buffers (a.k.a., protobuf) are Google's language-neutral,
 platform-neutral, extensible mechanism for serializing structured data. You
-can find [protobuf's documentation on the Google Developers site](https://developers.google.com/protocol-buffers/).
+can find [protobuf's documentation here](https://protobuf.dev/).
 
 All projects in this orgnaization are governed by
 [Protobuf's Code of Conduct](https://github.com/protocolbuffers/.github/blob/main/profile/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
The Protocol Buffers documentation URL has moved from developers.google.com to protobuf.dev.